### PR TITLE
Add status calculation for CulturalHeritageProperty

### DIFF
--- a/src/cultural-heritage-property/cultural-heritage-property/entity/cultural-heritage-property.entity.ts
+++ b/src/cultural-heritage-property/cultural-heritage-property/entity/cultural-heritage-property.entity.ts
@@ -6,6 +6,7 @@ import { CulturalRecordEntity } from '../../cultural-record/entities/cultural-re
 import { EntryAndLocationRecord } from '../../entry-and-location-record/entities/entry-and-location-record.entity';
 import { DescriptionControl } from '../../description-control/entities/description-control.entity';
 import { CulturalNoteEntity } from '../../cultural-notes/entities/cultural-note.entity';
+import { calculateOverallStatus } from '../util/calculate-overall-status.function';
 
 export class CulturalHeritageProperty implements CulturalPropertyModel {
   createdAt: Date;
@@ -30,7 +31,10 @@ export class CulturalHeritageProperty implements CulturalPropertyModel {
 
   uuid: string;
 
+  status?: 'Pending' | 'To Review' | 'Reviewed' | 'Has Issue';
+
   constructor(option: CulturalPropertyModel) {
+    console.log(option)
     this.createdAt = option.createdAt;
     this.deleted = option.deleted;
     this.updatedAt = option.updatedAt;
@@ -40,9 +44,7 @@ export class CulturalHeritageProperty implements CulturalPropertyModel {
       this.producerAuthor = ProducerAuthorRecord.create(option.producerAuthor);
 
     if (option.accessAndUseConditions)
-      this.accessAndUseConditions = AccessAndUseCondition.create(
-        option.accessAndUseConditions,
-      );
+      this.accessAndUseConditions = AccessAndUseCondition.create(option.accessAndUseConditions);
 
     if (option.associatedDocumentation)
       this.associatedDocumentation = AssociatedDocumentationEntity.create(
@@ -53,16 +55,14 @@ export class CulturalHeritageProperty implements CulturalPropertyModel {
       this.culturalRecord = CulturalRecordEntity.create(option.culturalRecord);
 
     if (option.entryAndLocation)
-      this.entryAndLocation = EntryAndLocationRecord.create(
-        option.entryAndLocation,
-      );
+      this.entryAndLocation = EntryAndLocationRecord.create(option.entryAndLocation);
 
     if (option.descriptionControl)
-      this.descriptionControl = DescriptionControl.create(
-        option.descriptionControl,
-      );
+      this.descriptionControl = DescriptionControl.create(option.descriptionControl);
 
     if (option.notes) this.notes = CulturalNoteEntity.create(option.notes);
+
+    this.status = option?.status ?? calculateOverallStatus(option);
   }
 
   static create(option: CulturalPropertyModel): CulturalHeritageProperty {

--- a/src/cultural-heritage-property/cultural-heritage-property/entity/cultural-heritage-property.entity.ts
+++ b/src/cultural-heritage-property/cultural-heritage-property/entity/cultural-heritage-property.entity.ts
@@ -34,7 +34,6 @@ export class CulturalHeritageProperty implements CulturalPropertyModel {
   status?: 'Pending' | 'To Review' | 'Reviewed' | 'Has Issue';
 
   constructor(option: CulturalPropertyModel) {
-    console.log(option)
     this.createdAt = option.createdAt;
     this.deleted = option.deleted;
     this.updatedAt = option.updatedAt;

--- a/src/cultural-heritage-property/cultural-heritage-property/models/cultural-property.model.ts
+++ b/src/cultural-heritage-property/cultural-heritage-property/models/cultural-property.model.ts
@@ -15,4 +15,5 @@ export interface CulturalPropertyModel extends BaseModel {
   associatedDocumentation: AssociatedDocumentationModel;
   culturalRecord: CulturalRecordModel;
   notes: NotesModel;
+  readonly status?: 'Pending' | 'To Review' | 'Reviewed' | 'Has Issue';
 }

--- a/src/cultural-heritage-property/cultural-heritage-property/util/calculate-overall-status.function.ts
+++ b/src/cultural-heritage-property/cultural-heritage-property/util/calculate-overall-status.function.ts
@@ -1,0 +1,77 @@
+export type StatusType = 'Pending' | 'To Review' | 'Reviewed' | 'Has Issue';
+
+export function calculateOverallStatus(obj: any): StatusType {
+  const statuses = extractAllStatuses(obj);
+
+  if (statuses.length === 0) return 'Pending';
+  if (statuses.includes('Pending')) return 'Pending';
+  if (statuses.includes('Has Issue')) return 'Has Issue';
+  if (statuses.every(s => s === 'Reviewed')) return 'Reviewed';
+
+  return 'To Review';
+}
+
+function extractAllStatuses(obj: any): StatusType[] {
+  const statuses: StatusType[] = [];
+  const visited = new WeakSet();
+  let depth = 0;
+  const MAX_DEPTH = 10;
+
+  function traverse(current: any): void {
+    if (depth > MAX_DEPTH) return;
+
+    if (!current || typeof current !== 'object') return;
+
+    if (visited.has(current)) return;
+    visited.add(current);
+
+    depth++;
+
+    try {
+      if (isFieldMetadata(current)) {
+        if (typeof current.status === 'string' && isValidStatus(current.status)) {
+          statuses.push(current.status as StatusType);
+        }
+        return;
+      }
+
+      if (Array.isArray(current)) {
+        current.forEach(item => traverse(item));
+        return;
+      }
+
+      const allowedProperties = [
+        'descriptionControl',
+        'entryAndLocation',
+        'producerAuthor',
+        'accessAndUseConditions',
+        'associatedDocumentation',
+        'culturalRecord',
+        'notes',
+      ];
+
+      Object.entries(current).forEach(([key, value]) => {
+        if (allowedProperties.includes(key) || isFieldMetadataProperty(key)) {
+          traverse(value);
+        }
+      });
+    } finally {
+      depth--;
+    }
+  }
+
+  traverse(obj);
+  return statuses;
+}
+
+function isFieldMetadata(obj: any): boolean {
+  return obj && typeof obj === 'object' && 'value' in obj && 'status' in obj && 'modifiedBy' in obj;
+}
+
+function isValidStatus(status: any): boolean {
+  return ['Pending', 'To Review', 'Reviewed', 'Has Issue'].includes(status);
+}
+
+function isFieldMetadataProperty(key: string): boolean {
+  return /^[a-zA-Z][a-zA-Z0-9]*$/.test(key) && !key.startsWith('_');
+}


### PR DESCRIPTION
---

### Summary

This pull request introduces a new feature to calculate the overall status for `CulturalHeritageProperty`.

### Changes

- Added a utility function `calculateOverallStatus` to determine the overall status based on metadata from nested fields.
- Introduced a `status` property in the `CulturalPropertyModel` and the `CulturalHeritageProperty` class.
- Modified the `CulturalHeritageProperty` constructor to assign a calculated status when no explicit status is provided.
- Removed debug `console.log` statements from the `CulturalHeritageProperty` constructor.

### Checklist

- [ ] Tests added for the new feature or bug fix
- [ ] Documentation updated (if necessary)
- [ ] All existing tests pass