### PR TITLE
fix(file-storage): size limit, MIME allowlist, header injection and Range handling [#API-26..30]

### DIFF
--- a/src/file-storage/file-storage.controller.ts
+++ b/src/file-storage/file-storage.controller.ts
@@ -1,8 +1,12 @@
 import {
+  BadRequestException,
   Controller,
   Delete,
   Get,
+  HttpException,
   Inject,
+  InternalServerErrorException,
+  Logger,
   NotFoundException,
   Param,
   Post,
@@ -21,10 +25,18 @@ import { EventEmitter } from '../shared/event-emitter/event-emitter.const';
 import { Request, Response } from 'express';
 import { Auth } from '../auth/decorator';
 import { UserRoles } from '../users/enum/user-roles.enum';
+import {
+  MAX_UPLOAD_BYTES,
+  contentDispositionInline,
+  parseByteRange,
+  uploadFileFilter,
+} from './file-storage.upload';
 
 @ApiTags('FileStorage')
 @Controller('file-storage')
 export class FileStorageController {
+  private readonly logger = new Logger(FileStorageController.name);
+
   constructor(
     @Inject(FILE_STORAGE_SERVICE_TOKEN)
     private readonly storageService: FileStorageServiceModel,
@@ -33,18 +45,29 @@ export class FileStorageController {
     roles: [UserRoles.administrator, UserRoles.manager, UserRoles.superAdmin],
   })
   @Post('upload')
-  @UseInterceptors(FileInterceptor('file'))
+  @UseInterceptors(
+    FileInterceptor('file', {
+      limits: { fileSize: MAX_UPLOAD_BYTES },
+      fileFilter: uploadFileFilter,
+    }),
+  )
   @ApiConsumes('multipart/form-data')
   @ApiBody({
-    description: 'List of cats',
+    description: 'File to store',
     type: FileUploadDto,
   })
   async uploadFile(@UploadedFile() file: Express.Multer.File) {
+    if (!file) {
+      throw new BadRequestException('File is required');
+    }
+
     try {
       const fileStorage = await this.storageService.uploadFile(file, file.originalname);
       return { message: `File successfully uploaded id: ${fileStorage.id}` };
     } catch (err) {
-      throw new NotFoundException('File not found. ' + err);
+      // The cause belongs in the log, not in the response body.
+      this.logger.error(`Upload of "${file.originalname}" failed`, err as Error);
+      throw new InternalServerErrorException('The file could not be stored.');
     }
   }
 
@@ -58,7 +81,7 @@ export class FileStorageController {
       await this.storageService.deleteFile(fileId);
       return { message: 'File successfully deleted.' };
     } catch (err) {
-      console.log(err);
+      this.logger.error(`Delete of file ${fileId} failed`, err as Error);
       throw new NotFoundException('File not found.');
     }
   }
@@ -87,33 +110,39 @@ export class FileStorageController {
         res.writeHead(200, {
           'Content-Length': file.length,
           'Content-Type': mime,
+          'Content-Disposition': contentDispositionInline(filename),
+          'X-Content-Type-Options': 'nosniff',
         });
 
         return fileStream.pipe(res);
       }
 
-      const parts = range.replace(/bytes=/, '').split('-');
-      const partialStart = parts[0];
-      const partialEnd = parts[1];
+      const parsed = parseByteRange(range, file.length);
 
-      const start = parseInt(partialStart, 10);
-      const end = partialEnd ? parseInt(partialEnd, 10) : file.length - 1;
-      const chunkSize = end - start + 1;
+      if (!parsed) {
+        // RFC 7233: an unsatisfiable range gets 416 plus the real size.
+        res.writeHead(416, { 'Content-Range': `bytes */${file.length}` });
+        return res.end();
+      }
+
+      const { start, end } = parsed;
 
       res.writeHead(206, {
         'Accept-Ranges': 'bytes',
-        'Content-Length': chunkSize,
-        'Content-Disposition': `inline;filename=${filename}`,
+        'Content-Length': end - start + 1,
+        'Content-Disposition': contentDispositionInline(filename),
+        'X-Content-Type-Options': 'nosniff',
         'Content-Range': `bytes ${start}-${end}/${file.length}`,
         'Content-Type': mime,
       });
 
       fileStream.pipe(res);
     } catch (err) {
-      if (err instanceof NotFoundException) {
+      if (err instanceof HttpException) {
         throw err;
       }
-      throw new NotFoundException('File not found. ' + err);
+      this.logger.error(`Serving file ${fileId} failed`, err as Error);
+      throw new NotFoundException('File not found.');
     }
   }
 }

--- a/src/file-storage/file-storage.upload.spec.ts
+++ b/src/file-storage/file-storage.upload.spec.ts
@@ -1,0 +1,98 @@
+import { BadRequestException } from '@nestjs/common';
+import {
+  ALLOWED_UPLOAD_MIME_TYPES,
+  contentDispositionInline,
+  parseByteRange,
+  uploadFileFilter,
+} from './file-storage.upload';
+
+describe('parseByteRange', () => {
+  const size = 1000;
+
+  it('parses a closed range', () => {
+    expect(parseByteRange('bytes=0-499', size)).toEqual({ start: 0, end: 499 });
+  });
+
+  it('defaults the end to the last byte', () => {
+    expect(parseByteRange('bytes=500-', size)).toEqual({ start: 500, end: 999 });
+  });
+
+  it('resolves a suffix range to the last N bytes', () => {
+    expect(parseByteRange('bytes=-200', size)).toEqual({ start: 800, end: 999 });
+  });
+
+  it('clamps an end past the file size', () => {
+    expect(parseByteRange('bytes=0-99999', size)).toEqual({ start: 0, end: 999 });
+  });
+
+  // Regression: parseInt('abc') produced NaN, which reached the response as
+  // "Content-Length: NaN" and broke the transfer instead of answering 416.
+  it.each([
+    ['bytes=abc-', 'non-numeric start'],
+    ['bytes=-', 'no bounds at all'],
+    ['bytes=', 'empty range'],
+    ['items=0-10', 'wrong unit'],
+    ['bytes=500-100', 'start after end'],
+    ['bytes=5000-6000', 'start past the file'],
+  ])('rejects %s (%s)', range => {
+    expect(parseByteRange(range, size)).toBeNull();
+  });
+
+  it('rejects any range against an empty file', () => {
+    expect(parseByteRange('bytes=0-10', 0)).toBeNull();
+  });
+});
+
+describe('contentDispositionInline', () => {
+  it('quotes a plain filename', () => {
+    expect(contentDispositionInline('photo.png')).toContain('filename="photo.png"');
+  });
+
+  // Regression: the filename went into the header raw, so a CR/LF in the stored
+  // name let the uploader append arbitrary response headers.
+  it('strips CR and LF so headers cannot be injected', () => {
+    const header = contentDispositionInline('a.png\r\nSet-Cookie: admin=1');
+
+    expect(header).not.toContain('\r');
+    expect(header).not.toContain('\n');
+    expect(header).toContain('filename="a.pngSet-Cookie: admin=1"');
+  });
+
+  it('strips embedded quotes so the value cannot be closed early', () => {
+    expect(contentDispositionInline('a".png')).toContain('filename="a.png"');
+  });
+
+  it('keeps a UTF-8 form for non-ascii names', () => {
+    const header = contentDispositionInline('cerámica.png');
+
+    expect(header).toContain("filename*=UTF-8''");
+    expect(header).toContain(encodeURIComponent('cerámica.png'));
+  });
+
+  it('falls back to a generic name when nothing usable is left', () => {
+    expect(contentDispositionInline('\r\n')).toContain('filename="file"');
+  });
+});
+
+describe('uploadFileFilter', () => {
+  const run = (mimetype: string) => {
+    const callback = jest.fn();
+    uploadFileFilter({}, { mimetype } as Express.Multer.File, callback);
+    return callback;
+  };
+
+  it.each(ALLOWED_UPLOAD_MIME_TYPES)('accepts %s', mimetype => {
+    expect(run(mimetype)).toHaveBeenCalledWith(null, true);
+  });
+
+  // SVG is XML and can carry script; these files are served back inline from
+  // the same origin, so accepting it would be stored XSS.
+  it.each(['image/svg+xml', 'text/html', 'application/javascript', 'application/x-msdownload'])(
+    'rejects %s',
+    mimetype => {
+      const callback = run(mimetype);
+
+      expect(callback).toHaveBeenCalledWith(expect.any(BadRequestException), false);
+    },
+  );
+});

--- a/src/file-storage/file-storage.upload.ts
+++ b/src/file-storage/file-storage.upload.ts
@@ -1,0 +1,104 @@
+import { BadRequestException } from '@nestjs/common';
+
+/**
+ * Upload ceiling for the generic file-storage endpoint.
+ *
+ * Multer buffers the whole upload in memory, so without a limit a single
+ * request could exhaust the process heap.
+ */
+export const MAX_UPLOAD_BYTES = 50 * 1024 * 1024;
+
+/**
+ * Types the panel actually uploads: still images, video and audio attachments
+ * for heritage records, plus PDF documentation.
+ *
+ * SVG is deliberately absent. It is an XML document that can carry script, and
+ * these files are served back inline from the same origin.
+ */
+export const ALLOWED_UPLOAD_MIME_TYPES = [
+  'image/jpeg',
+  'image/jpg',
+  'image/png',
+  'image/webp',
+  'image/gif',
+  'video/mp4',
+  'video/webm',
+  'video/ogg',
+  'audio/mpeg',
+  'audio/ogg',
+  'audio/wav',
+  'audio/webm',
+  'application/pdf',
+];
+
+type FileFilterCallback = (error: Error | null, acceptFile: boolean) => void;
+
+export function uploadFileFilter(
+  _req: unknown,
+  file: Express.Multer.File,
+  callback: FileFilterCallback,
+): void {
+  if (!ALLOWED_UPLOAD_MIME_TYPES.includes(file.mimetype)) {
+    callback(new BadRequestException(`Unsupported file type: ${file.mimetype}`), false);
+    return;
+  }
+  callback(null, true);
+}
+
+/**
+ * Builds a Content-Disposition header that cannot be broken out of.
+ *
+ * The stored filename is attacker-supplied, so quotes, CR and LF have to go:
+ * a raw newline would let the uploader inject arbitrary response headers.
+ */
+export function contentDispositionInline(filename: string): string {
+  const fallback = (filename ?? '')
+    .replace(/[\r\n"\\]/g, '')
+    .replace(/[^\x20-\x7e]/g, '_')
+    .trim();
+
+  const safeFallback = fallback.length > 0 ? fallback : 'file';
+
+  return `inline; filename="${safeFallback}"; filename*=UTF-8''${encodeURIComponent(filename ?? '')}`;
+}
+
+/**
+ * Parses a single `bytes=` range against the known file size.
+ *
+ * Returns null when the header is malformed or unsatisfiable so the caller can
+ * answer 416 instead of emitting a NaN Content-Length.
+ */
+export function parseByteRange(
+  range: string,
+  size: number,
+): { start: number; end: number } | null {
+  const match = /^bytes=(\d*)-(\d*)$/.exec(range.trim());
+
+  if (!match || size <= 0) {
+    return null;
+  }
+
+  const [, rawStart, rawEnd] = match;
+
+  if (rawStart === '' && rawEnd === '') {
+    return null;
+  }
+
+  // A suffix range ("bytes=-500") asks for the last N bytes.
+  if (rawStart === '') {
+    const suffix = Number(rawEnd);
+    if (suffix === 0) {
+      return null;
+    }
+    return { start: Math.max(0, size - suffix), end: size - 1 };
+  }
+
+  const start = Number(rawStart);
+  const end = rawEnd === '' ? size - 1 : Math.min(Number(rawEnd), size - 1);
+
+  if (start > end || start >= size) {
+    return null;
+  }
+
+  return { start, end };
+}


### PR DESCRIPTION
Hardens the file upload and download path. Five findings, all on the same two handlers.

| id | severity | finding |
|---|---|---|
| API-26 | high | Uploads had no size limit — `FileInterceptor('file')` with no `limits` |
| API-27 | high | No MIME allowlist. SVG was accepted and served back **inline, same-origin** |
| API-28 | high | `Content-Disposition` was built from the stored filename with no sanitising, so CR/LF in a name injects response headers |
| API-29 | medium | Malformed `Range` headers produced nonsense. `bytes=abc-` → `Content-Length: NaN`; `bytes=5000-6000` on a 1000-byte file → `Content-Length: 1001` |
| API-30 | medium | Storage errors leaked the raw driver error to the client, plus a `console.log(err)` in the controller |

**Verification:** 33 new test cases covering these paths specifically. Before, `bytes=abc-` returned `Content-Length: NaN`; now it returns `416` with `Content-Range: bytes */size` per RFC 7233. Suite goes from 58 to **91 tests**, 37 suites, all green.

**Not verified:** the handlers were exercised through their unit tests, not through real HTTP uploads against a running server.

---

**Stack:** base is `fix/api-lint-gate`. Full order in `docs/audit-2026-08.md` §4.

**Related, out of scope:** API-40 — `multer@1.4.5-lts.2` is end-of-life and carries advisories patched only in 2.x. That is a MAJOR bump and needs its own batch and its own approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
