### PR TITLE
fix(deps): handlebars 4.7.8 -> 4.7.9, JS injection advisory [#API-39]

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "cache-manager": "^6.4.3",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
-    "handlebars": "^4.7.8",
+    "handlebars": "^4.7.9",
     "joi": "^17.13.3",
     "lodash": "^4.17.21",
     "luxon": "^3.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: ^0.14.1
         version: 0.14.1
       handlebars:
-        specifier: ^4.7.8
-        version: 4.7.8
+        specifier: ^4.7.9
+        version: 4.7.9
       joi:
         specifier: ^17.13.3
         version: 17.13.3
@@ -2869,8 +2869,8 @@ packages:
     resolution: {integrity: sha512-tSQXBXS/MWQOn/RKckawJ61vvsDpCom87JgxiYdGwHdOa0ht0vzUWDlfioofFCRU0L+6NGDt6XzbgoJvZkMeRQ==}
     engines: {node: '>=0.8.0'}
 
-  handlebars@4.7.8:
-    resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
+  handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
     engines: {node: '>=0.4.7'}
     hasBin: true
 
@@ -5685,7 +5685,7 @@ snapshots:
       fast-glob: 3.3.3
       fs-extra: 11.3.0
       glob: 11.0.1
-      handlebars: 4.7.8
+      handlebars: 4.7.9
       html-entities: 2.6.0
       i18next: 23.16.8
       json5: 2.2.3
@@ -8048,7 +8048,7 @@ snapshots:
 
   hammerjs@2.0.8: {}
 
-  handlebars@4.7.8:
+  handlebars@4.7.9:
     dependencies:
       minimist: 1.2.8
       neo-async: 2.6.2


### PR DESCRIPTION
**API-39 (critical, security):** `handlebars@4.7.8` carries a JS injection advisory. It is a direct production dependency, used by the email templates (`shared/email/email-nodemailer.service.ts:5`).

Bumped to `4.7.9`.

### The lockfile was edited by hand — on purpose

4.7.9 declares the same dependency ranges and the same engines as 4.7.8, so the resolution graph is unchanged and the honest diff is a version string plus an integrity hash. A plain `pnpm install` under the pnpm 11 / lockfile 9.0 mismatch would have rewritten the entire file (~4655 lines, ~200 unrelated transitive bumps), which the audit brief explicitly rules out.

Result: a **12-line lockfile diff**, zero transitive bumps.

**Verification:**
- The sha512 recorded in the lockfile was checked **byte for byte against the real tarball downloaded from npm**, not copied from a lockfile generated elsewhere.
- `Handlebars.compile()` was executed on 4.7.9 and confirmed to still render the template shape the email service uses.

**Not verified:** a from-scratch install on a clean machine.

---

**Stack:** base is `fix/api-auth-throttle`. This is the top of the API stack. Full order in `docs/audit-2026-08.md` §4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
