### PR TITLE
docs: add the audit pass 2 report

### DIFF
--- a/docs/audit-2026-08.md
+++ b/docs/audit-2026-08.md
@@ -1,0 +1,147 @@
+# Museo API — Audit Report (August 2026)
+
+Read-only diagnosis first, triage second, fixes in small batches. This file is the
+report the batches reference by id. The previous audit pass left no report
+committed anywhere, which is why its seven branches sat unmerged and unexplained
+for months; this one is committed before the fixes land.
+
+- **Base branch:** `develop`
+- **Toolchain note:** installs must use `npx pnpm@10`. The globally installed
+  pnpm 11 disagrees with the settings block of this `lockfileVersion: '9.0'`
+  lockfile and re-resolves the whole graph (measured: 4655 changed lines, ~200
+  unrelated transitive bumps). pnpm 10 is a zero-diff no-op against it.
+
+---
+
+## 1. Findings
+
+Severity is about impact on a running deployment. Effort is S (< 1h), M (a few
+hours), L (a day or more).
+
+### 1.1 Carried over from audit pass 1 (already fixed, never merged)
+
+These were found and fixed by an earlier pass whose work was never merged into
+`develop`. Evidence is the commit that fixes each one; they are listed so the
+consolidated branch can be reviewed as a whole.
+
+| id | finding | evidence | severity | type |
+|---|---|---|---|---|
+| API-02 | An expired recovery code was still accepted by `changePassword` | `4605b68` | critical | security |
+| API-03 | A failed user update was reported to the caller as success | `4605b68` | high | correctness |
+| API-04 | Refresh token stored in plaintext; now a digest | `d4539d0` | high | security |
+| API-05 | `app.enableCors()` with no options — every origin allowed | `main.ts`, fixed on `fix/api-hardening` | high | security |
+| API-07 | ESLint config was `.eslintrc`, which ESLint 9 no longer reads | `e86cc46` | medium | dx |
+| API-08 | Scaffolded specs missing DI mocks, suites could not instantiate | `cfab0a2` | medium | tests |
+| API-09 | Type errors in the nomenclator specs | `504c375` | medium | tests |
+| API-13 | `bootstrap()` had no `.catch()`; startup failures were silent | `9f911fa` | medium | ops |
+| API-14 | Config module imported itself | `b4f52ec` | low | debt |
+| API-15 | Unused activation guard | `3748367` | low | debt |
+| API-16 | Unused development env module | `04e56b4` | low | debt |
+| API-17 | `console.*` instead of the Nest logger | `41f812d` | low | ops |
+| API-18 | `EMAIL_SECURE` ignored, TLS hardcoded | `4ebf512` | medium | correctness |
+| API-19 | `sample.env` did not match the variables the app reads | `db161c8` | medium | dx |
+| API-20 | Recovery email copy and markup wrong | `9417b25` | low | correctness |
+| API-23 | Remaining non-formatting ESLint findings | `72aa3b2` | low | debt |
+
+### 1.2 New in this pass
+
+| id | finding | evidence | severity | type | effort |
+|---|---|---|---|---|---|
+| API-25 | Recovery code was `random % 100000`: biased, could be shorter than 5 digits, and unlimited guesses were free. Measured over 200k draws: 86448 distinct values, **10.1% shorter than 5 digits** | `auth.service.ts`, `generateRandomFiveDigitNumber` | high | security | M |
+| API-26 | Uploads had no size limit | `file-storage.controller.ts`, `FileInterceptor('file')` with no `limits` | high | security | S |
+| API-27 | Uploads had no MIME allowlist; SVG was accepted and served back inline same-origin | same interceptor, no `fileFilter` | high | security | S |
+| API-28 | `Content-Disposition` built from the stored filename with no sanitising — CR/LF in a name injects response headers | `file-storage.controller.ts`, download handler | high | security | S |
+| API-29 | Malformed `Range` headers produced nonsense responses. `bytes=abc-` → `Content-Length: NaN`; `bytes=5000-6000` on a 1000-byte file → `Content-Length: 1001` | same handler | medium | correctness | M |
+| API-30 | Storage errors leaked the raw driver error to the client; `console.log(err)` in the controller | same handler | medium | security | S |
+| API-31 | `forgotPassword` returned 404 for unknown addresses, enumerating registered emails | `auth.service.ts`, `forgotPassword` | medium | security | S |
+| API-32 | The recovery email was sent **before** the code was persisted, so a failed write handed the user a code that could never validate | same method | medium | correctness | S |
+| API-33 | `pnpm lint` did not start at all under ESLint 9, and with Prettier as a lint rule reported **15616** violations on a codebase never formatted with that config — the gate was unusable | `eslint.config.mjs`, `.prettierrc` | high | dx | M |
+| API-36 | README was the NestJS boilerplate description and never mentioned creating `.env` | `README.md` | low | dx | S |
+| API-39 | `handlebars@4.7.8` — JS injection advisory, direct production dependency used by the email templates | `package.json:44`, `shared/email/email-nodemailer.service.ts:5` | critical | security | S |
+
+### 1.3 Withdrawn
+
+| id | why |
+|---|---|
+| API-35 | Reported as "`docs/tasks.md` claims 80%+ coverage is done". **False.** The Testing section of `docs/tasks.md` is entirely unchecked; the 80% figure is a goal in `docs/plan.md`, not a completed claim. Removed from scope. |
+
+---
+
+## 2. What was fixed, by batch
+
+Every batch is stacked on `fix/api-lint-gate`, because that branch is what makes
+`lint` a usable verification gate for the ones after it.
+
+| batch / branch | ids | verification |
+|---|---|---|
+| `integration/audit-pass-1` | consolidates pass 1 (4 lines of work, 7 branches) | 36 suites / 58 tests green. One trivial conflict in `sample.env`, resolved additively |
+| `fix/api-lint-gate` (`a851f8b`) | API-33, API-36 | **15616 → 0** ESLint errors with **zero code reformatted**. Formatting moved out of ESLint entirely (`eslint-config-prettier`, already a devDependency); `format:check` now owns it |
+| `fix/api-file-storage` (`7d6630e`) | API-26..30 | 33 new cases. Before: `bytes=abc-` → `Content-Length: NaN`. After: `416`. 37 suites / 91 tests |
+| `fix/api-auth-throttle` (`0329aae`) | API-25, API-31, API-32 | Before: 86448 distinct codes / 200k, 10.1% under-length. After: 179366 distinct, 0 out of range. 5-attempt counter, then the code is burned. 37 suites / 97 tests |
+| `fix/api-deps` (`4cfa51e`) | API-39 | sha512 of the real npm tarball verified byte-for-byte against the recorded resolution; `Handlebars.compile` checked to still render on 4.7.9. **12-line** lockfile diff, no transitive bumps |
+
+**Final state:** `eslint` 0 · `nest build` 0 · **37 suites / 97 tests**.
+
+### Design decisions worth knowing
+
+- **API-25 used an attempt counter, not `@nestjs/throttler`.** Adding the package
+  would have regenerated the lockfile under the pnpm mismatch and dragged in
+  unrequested bumps. The counter also survives a process restart, which
+  in-memory throttling does not.
+- **API-33 did not reformat anything.** Running Prettier as an ESLint rule is
+  what produced the 15616 figure. Formatting is now a separate concern, which is
+  what Prettier's own documentation recommends.
+- **API-39 edited the lockfile by hand.** 4.7.9 declares the same dependency
+  ranges and engines as 4.7.8, so the resolution graph is unchanged and the edit
+  is a version string plus an integrity hash. A plain install would have rewritten
+  the whole file.
+
+---
+
+## 3. Out of scope
+
+| id | finding | evidence | why not now |
+|---|---|---|---|
+| API-34 | 31 of 37 spec files contain only the `should be defined` scaffold | `src/**/*.spec.ts` | Effort L. Writing real tests for 31 modules is its own project, not an audit fix |
+| API-37 | 12 near-identical nomenclator CRUD modules | `src/nomenclator/` — 12 of 14 subfolders, services 57–91 lines with the same shape | Effort L, and the fix is a generic base class or factory — a rewrite, which the brief prohibits |
+| API-40 | `multer@1.4.5-lts.2` is end-of-life and carries advisories patched only in 2.x | `package.json:50` | Major bump. Needs its own batch and its own approval; the upload path changed in this pass already |
+
+---
+
+## 4. Merge order
+
+The batches are stacked, not independent. Merge in this order:
+
+```
+integration/audit-pass-1
+  └─ fix/api-lint-gate
+       └─ fix/api-file-storage
+            └─ fix/api-auth-throttle
+                 └─ fix/api-deps
+```
+
+`docs/audit-pass-2` (this file) branches off `integration/audit-pass-1` and can
+merge at any point.
+
+### Deviation from the brief
+
+Phase 7 asked for `git worktree add`. A fresh worktree has no `node_modules`, and
+installing one would regenerate the lockfile under the pnpm version mismatch
+described at the top. Branches in the main working tree were used instead, so
+"one batch = one branch" still holds.
+
+---
+
+## 5. Recommendations for the next pass
+
+1. **Pin `packageManager: "pnpm@10.x"` in `package.json`.** Nothing currently
+   records which pnpm this lockfile belongs to, so anyone on pnpm 11 rewrites it
+   wholesale on their first install. This is one line and prevents a category of
+   accidental dependency churn.
+2. **Take API-34 seriously.** 31 of 37 suites assert only that a class can be
+   instantiated. Coverage numbers from this suite mean nothing, and every fix in
+   this pass had to ship its own characterization tests before it could be
+   verified. Pick the modules that handle money, files and auth first.
+3. **Plan the `multer` 2.x migration (API-40).** It is end-of-life, it is on the
+   upload path that this pass just hardened, and leaving it means the file-storage
+   work has to be revisited.


### PR DESCRIPTION
Adds `docs/audit-2026-08.md`, the report the other PRs in this stack reference by id.

Audit pass 1 left no report committed anywhere. That is why its seven branches sat unmerged and unexplained for months, and it is why this one is committed rather than left in a chat log.

Contents:
- **§1** every finding with its evidence as `file:line` or commit SHA — pass 1 carried over, plus the 11 new ones (API-25..API-39), plus API-35 recorded as **withdrawn** because it turned out to be false.
- **§2** what each batch fixed and how it was actually verified, with real before/after numbers.
- **§3** what was deliberately left out and why (API-34, API-37, API-40).
- **§4** the merge order, because the branches are a stack and not independent PRs.
- **§5** three recommendations for the next pass.

Written in English to match the existing `docs/` folder and the commit history.

---

**Stack:** base is `integration/audit-pass-1`. This PR touches only `docs/` and can merge at any point in the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
